### PR TITLE
#7: Fix warning about update_last_removed

### DIFF
--- a/conversions/end.inc
+++ b/conversions/end.inc
@@ -421,7 +421,9 @@ function coder_upgrade_create_update_last_removed($module_name, &$reader, &$node
         $ns[$matches[2]] = $node;
       }
     }
-    $last_removed = max(array_keys($ns));
+    if ($last_removed != '') {
+      $last_removed = max(array_keys($ns));
+    }
   }
 
   // Set values for the new hook function.


### PR DESCRIPTION
Not 100% sure it's okay to just skip creating the `_update_last_removed` but if there isn't one to remove I guess there isn't something to add?