### PR TITLE
Fix missing config/install info

### DIFF
--- a/coder_upgrade.module
+++ b/coder_upgrade.module
@@ -180,9 +180,5 @@ function coder_upgrade_build_config_function($node, $reader) {
   // Insert the new function before the old function.
   $container->insertBefore($node, $function, 'function');
   // Insert a blank line.
-  $whitespace = array(
-    'type' => T_WHITESPACE,
-    'value' => 1,
-  );
   $container->insertBefore($node, CODER_UPGRADE_WHITESPACE, 'whitespace');
 }

--- a/coder_upgrade.module
+++ b/coder_upgrade.module
@@ -5,7 +5,7 @@
  *
  * Developer module that assists a contributed module with version upgrade from
  * the Drupal 7.x to Backdrop 1.x core API. The module creates new code files by
- * modifying existing code files in accordance with the core API changes. The 
+ * modifying existing code files in accordance with the core API changes. The
  * initial Backdrop version would be a straight port of features from the Drupal
  * version.
  *
@@ -14,6 +14,11 @@
  *
  * Copyright 2008-11 by Jim Berry ("solotandem", http://drupal.org/user/240748)
  */
+
+/**
+ * Defines an array used to insert blank lines into created code.
+ */
+define('CODER_UPGRADE_WHITESPACE', array('type' => T_WHITESPACE, 'value' => 1 ));
 
 if (function_exists('t')) {
   // This code is being executed inside a process running Backdrop.
@@ -162,16 +167,12 @@ function coder_upgrade_build_config_function($node, $reader) {
   $function->parameters = new PGPList();
 
   $strings[] = '$prefixes[\'' . $_coder_upgrade_module_name . '.settings\'] = array(';
-  $strings[] = "  'label' => t('Module name settings'),";
+  $strings[] = "  'label' => t('<Module name> settings'),";
   $strings[] = "  'group' => t('Configuration'),";
   $strings[] = ');';
   $strings[] = 'return $prefixes;';
 
-  $body_content = $editor->textToStatements(implode("\n", $strings))->getElement();
-
-  $body = new PGPBody();
-  $body->insertLast($body_content);
-  $function->body = $body;
+  $function->body = $editor->textToStatements(implode("\n", $strings));
 
   // Get the statement list the function node is part of.
   $container = &$node->container;
@@ -183,5 +184,5 @@ function coder_upgrade_build_config_function($node, $reader) {
     'type' => T_WHITESPACE,
     'value' => 1,
   );
-  $container->insertBefore($node, $whitespace, 'whitespace');
+  $container->insertBefore($node, CODER_UPGRADE_WHITESPACE, 'whitespace');
 }

--- a/coder_upgrade.module
+++ b/coder_upgrade.module
@@ -150,7 +150,7 @@ function coder_upgrade_upgrade_file_alter(&$reader) {
 }
 
 function coder_upgrade_build_config_function($node, $reader) {
-  global $_coder_upgrade_module_name;
+  global $_coder_upgrade_module_name, $_coder_upgrade_module_human_name;
   $editor = PGPEditor::getInstance();
 
   // Set values for the new hook function.
@@ -167,7 +167,7 @@ function coder_upgrade_build_config_function($node, $reader) {
   $function->parameters = new PGPList();
 
   $strings[] = '$prefixes[\'' . $_coder_upgrade_module_name . '.settings\'] = array(';
-  $strings[] = "  'label' => t('<Module name> settings'),";
+  $strings[] = "  'label' => t('{$_coder_upgrade_module_human_name} settings'),";
   $strings[] = "  'group' => t('Configuration'),";
   $strings[] = ');';
   $strings[] = 'return $prefixes;';

--- a/conversions/end.inc
+++ b/conversions/end.inc
@@ -52,9 +52,9 @@ function coder_upgrade_upgrade_end_alter($dirname) {
       // Adds an entry to hook_install if there are dynamically created variables.
       coder_upgrade_install_file($module_name, $install_file, $config);
 
-      // Creates a config directory and file if there were variable to config 
+      // Creates a config directory and file if there were variable to config
       // conversions.
-      coder_upgrade_build_config_files($module_path, $module_name, $config); // todo 
+      coder_upgrade_build_config_files($module_path, $module_name, $config); // todo
     }
   }
 }
@@ -125,7 +125,7 @@ function coder_upgrade_create_autoload($module_name, $module_path, $classes) {
     foreach ($classes as $path => $class_nodes) {
       $is_test_file = pathinfo($path, PATHINFO_EXTENSION) == 'test';
       if (!$is_test_file) {
-        foreach ($class_nodes['classes'] as $class_node) {      
+        foreach ($class_nodes['classes'] as $class_node) {
           $strings[] = "'" . $class_node->data->name . "' => '" . $path . "',";
         }
       }
@@ -161,11 +161,7 @@ function coder_upgrade_create_autoload($module_name, $module_path, $classes) {
     // Insert the new function before the old function.
     $container->insertAfter($node, $function, 'function');
     // Insert a blank line.
-    $whitespace = array(
-      'type' => T_WHITESPACE,
-      'value' => 1,
-    );
-    $container->insertAfter($node, $whitespace, 'whitespace');
+    $container->insertAfter($node, CODER_UPGRADE_WHITESPACE, 'whitespace');
 
     // Use writer to redo file.
     $writer = PGPWriter::getInstance();
@@ -276,7 +272,7 @@ function coder_upgrade_install_file($module_name, $install_file, $config) {
   coder_upgrade_memory_print('reset reader');
 }
 
- 
+
 function coder_upgrade_create_update_install($module_name, &$reader, &$nodes, $config_data) {
   // Use the editor to set the function parameters.
   $editor = PGPEditor::getInstance();
@@ -333,11 +329,7 @@ function coder_upgrade_create_update_install($module_name, &$reader, &$nodes, $c
     // Insert the new function before the old function.
     $container->insertAfter($node, $function, 'function');
     // Insert a blank line.
-    $whitespace = array(
-      'type' => T_WHITESPACE,
-      'value' => 1,
-    );
-    $container->insertAfter($node, $whitespace, 'whitespace');
+    $container->insertAfter($node, CODER_UPGRADE_WHITESPACE, 'whitespace');
   }
   else {
     $item = &$install_function->data;
@@ -372,6 +364,12 @@ function coder_upgrade_create_update_1000($module_name, &$reader, &$nodes, $conf
     $body->insertLast($body_content);
   }
 
+  $string = "\$config->save();";
+  $body_content = $editor->textToStatements($string)->getElement(0);
+  $body->insertLast($body_content);
+
+  $body->insertLast(CODER_UPGRADE_WHITESPACE, 'whitespace');
+
   foreach ($config_data as $key => $line) {
     $string = '  update_variable_del(\'' . $key . '\');';
     $body_content = $editor->textToStatements($string)->getElement(0);
@@ -399,11 +397,7 @@ function coder_upgrade_create_update_1000($module_name, &$reader, &$nodes, $conf
   // Insert the new function before the old function.
   $container->insertAfter($node, $function, 'function');
   // Insert a blank line.
-  $whitespace = array(
-    'type' => T_WHITESPACE,
-    'value' => 1,
-  );
-  $container->insertAfter($node, $whitespace, 'whitespace');
+  $container->insertAfter($node, CODER_UPGRADE_WHITESPACE, 'whitespace');
 }
 
 function coder_upgrade_create_update_last_removed($module_name, &$reader, &$nodes) {
@@ -451,11 +445,7 @@ function coder_upgrade_create_update_last_removed($module_name, &$reader, &$node
       // Insert the new function before the old function.
       $container->insertAfter($node, $function, 'function');
       // Insert a blank line.
-      $whitespace = array(
-        'type' => T_WHITESPACE,
-        'value' => 1,
-      );
-      $container->insertAfter($node, $whitespace, 'whitespace');
+      $container->insertAfter($node, CODER_UPGRADE_WHITESPACE, 'whitespace');
     }
   }
 }
@@ -489,7 +479,7 @@ function coder_upgrade_get_file_classes($file) {
   $classes = &$reader->getClasses();
   $functions = &$reader->getFunctions();
 
-  // $classes doesnt seem to hold any information about contained functions so
+  // $classes doesn't seem to hold any information about contained functions so
   // return both.
   if (!empty($classes)) {
     return array(
@@ -513,11 +503,11 @@ function _coder_upgrade_sort_files_by_modules($files, $modules) {
   // We have here an array of files with classes in them, and an array of paths
   // to directories with a ".module' file. We assume the latter are likely to be
   // sub-modules of the currently converting project item. We can't do a simple
-  // strpos() to find which module directory a class file belongs to because 
-  // for a file "dira/dirb/file.file", strpos() would match both dira/ and 
+  // strpos() to find which module directory a class file belongs to because
+  // for a file "dira/dirb/file.file", strpos() would match both dira/ and
   // dira/dirb/.
   // So we sort the module directories by depth, check each file to see if it
-  // belongs there, then remove the file from the search so it won't match a 
+  // belongs there, then remove the file from the search so it won't match a
   // shallower directory.
   uasort ($modules , function ($a, $b) {
     $deptha = substr_count($a, '/');

--- a/conversions/other.inc
+++ b/conversions/other.inc
@@ -1936,9 +1936,5 @@ function coder_upgrade_op_to_hook($node, $case_node, $hook, $parameters) {
   // Insert the new function before the old function.
   $container->insertBefore($node, $function, 'function');
   // Insert a blank line.
-  $whitespace = array(
-    'type' => T_WHITESPACE,
-    'value' => 1,
-  );
-  $container->insertBefore($node, $whitespace, 'whitespace');
+  $container->insertBefore($node, CODER_UPGRADE_WHITESPACE, 'whitespace');
 }

--- a/conversions/tool.inc
+++ b/conversions/tool.inc
@@ -269,11 +269,7 @@ function coder_upgrade_op_to_hook($node, $case_node, $hook, $parameters) {
   // Insert the new function before the old function.
   $container->insertBefore($node, $function, 'function');
   // Insert a blank line.
-  $whitespace = array(
-    'type' => T_WHITESPACE,
-    'value' => 1,
-  );
-  $container->insertBefore($node, $whitespace, 'whitespace');
+  $container->insertBefore($node, CODER_UPGRADE_WHITESPACE, 'whitespace');
 }
 
 /**

--- a/grammar_parser/list.inc
+++ b/grammar_parser/list.inc
@@ -2305,7 +2305,7 @@ class PGPString extends PGPExpression {
 
         case 'open':
         case 'close':
-          $string .= $data['value'] ?? $data;
+          $string .= isset($data['value']) ? $data['value'] : $data;
           break;
 
         case 'operand':

--- a/grammar_parser/list.inc
+++ b/grammar_parser/list.inc
@@ -2305,7 +2305,7 @@ class PGPString extends PGPExpression {
 
         case 'open':
         case 'close':
-          $string .= $data['value'];
+          $string .= $data['value'] ?? $data;
           break;
 
         case 'operand':

--- a/grammar_parser/list.inc
+++ b/grammar_parser/list.inc
@@ -2305,7 +2305,7 @@ class PGPString extends PGPExpression {
 
         case 'open':
         case 'close':
-          $string .= isset($data['value']) ? $data['value'] : $data;
+          $string .= $data['value'];
           break;
 
         case 'operand':

--- a/includes/main.inc
+++ b/includes/main.inc
@@ -557,39 +557,19 @@ function coder_upgrade_module_name($dirname, &$item) {
   foreach ($files as $file) {
     $file_path = $path . $file;
     if (!is_dir($file_path)) {
-      $pathinfo = pathinfo($file_path, PATHINFO_EXTENSION);
-      if ($pathinfo == 'info') {
+      $extension = pathinfo($file_path, PATHINFO_EXTENSION);
+      if ($extension == 'info') {
         $item['module'] = pathinfo($file_path, PATHINFO_FILENAME);
-        $item['module_human_name'] = _coder_upgrade_module_human_name($file_path);
+        $info = backdrop_parse_info_file($file_path);
+        $item['module_human_name'] = $info['name'];
         break;
       }
-      elseif ($pathinfo == 'module') {
+      elseif ($extension == 'module') {
         $item['module'] = pathinfo($file_path, PATHINFO_FILENAME);
         // Don't break because we might still be looking for the human name
       }
     }
   }
-}
-
-/**
- * Get the human name of the module from its .info file.
- */
-function _coder_upgrade_module_human_name($file_path) {
-  $file = fopen($file_path, "r");
-  if ($file) {
-    $contents = fread($file, filesize($file_path));
-    fclose($file);
-    if ($contents) {
-      $lines = explode("\n", $contents);
-      foreach ($lines as $line) {
-        $parts = explode('=', $line);
-        if (count($parts) == 2 && trim($parts[0]) == 'name') {
-          return trim($parts[1]);
-        }
-      }
-    }
-  }
-  return '';
 }
 
 /**

--- a/includes/main.inc
+++ b/includes/main.inc
@@ -27,7 +27,7 @@
  */
 function coder_upgrade_start($upgrades, $extensions, $items, $recursive = TRUE) {
   // Declare global variables.
-  global $_coder_upgrade_log, $_coder_upgrade_debug, $_coder_upgrade_module_name, $_coder_upgrade_replace_files, $_coder_upgrade_class_files;
+  global $_coder_upgrade_log, $_coder_upgrade_debug, $_coder_upgrade_module_name, $_coder_upgrade_module_human_name, $_coder_upgrade_replace_files, $_coder_upgrade_class_files;
 //  global $_coder_upgrade_dirname; // Not used.
 
   // Check lists in case this function is called apart from form submit.
@@ -72,6 +72,7 @@ function coder_upgrade_start($upgrades, $extensions, $items, $recursive = TRUE) 
     // Set the module name so the <convert_begin_alter> functions have this.
     coder_upgrade_module_name($item['old_dir'], $item);
     $_coder_upgrade_module_name = !empty($item['module']) ? $item['module'] : '';
+    $_coder_upgrade_module_human_name = !empty($item['module_human_name']) ? $item['module_human_name'] : '';
 
     if (!isset($_SERVER['HTTP_USER_AGENT']) || strpos($_SERVER['HTTP_USER_AGENT'], 'simpletest') === FALSE) {
       // Process the directory before conversion routines are applied.
@@ -539,9 +540,6 @@ function coder_upgrade_convert_functions(&$reader) {
  *   Array of a directory containing the files to convert.
  */
 function coder_upgrade_module_name($dirname, &$item) {
-  // Extensions that indicate a module is present.
-  $extensions = array('info', 'module');
-
   /*
    * Set the module name in case there is no module in the directory (e.g. po
    * or translations).
@@ -559,12 +557,39 @@ function coder_upgrade_module_name($dirname, &$item) {
   foreach ($files as $file) {
     $file_path = $path . $file;
     if (!is_dir($file_path)) {
-      if (in_array(pathinfo($file_path, PATHINFO_EXTENSION), $extensions)) {
+      $pathinfo = pathinfo($file_path, PATHINFO_EXTENSION);
+      if ($pathinfo == 'info') {
         $item['module'] = pathinfo($file_path, PATHINFO_FILENAME);
+        $item['module_human_name'] = _coder_upgrade_module_human_name($file_path);
         break;
+      }
+      elseif ($pathinfo == 'module') {
+        $item['module'] = pathinfo($file_path, PATHINFO_FILENAME);
+        // Don't break because we might still be looking for the human name
       }
     }
   }
+}
+
+/**
+ * Get the human name of the module from its .info file.
+ */
+function _coder_upgrade_module_human_name($file_path) {
+  $file = fopen($file_path, "r");
+  if ($file) {
+    $contents = fread($file, filesize($file_path));
+    fclose($file);
+    if ($contents) {
+      $lines = explode("\n", $contents);
+      foreach ($lines as $line) {
+        $parts = explode('=', $line);
+        if (count($parts) == 2 && trim($parts[0]) == 'name') {
+          return trim($parts[1]);
+        }
+      }
+    }
+  }
+  return '';
 }
 
 /**


### PR DESCRIPTION
Several related changes, all to do with fixing the missing `return $prefixes;` in implementations of `hook_config_info()` and missing `$config->save();` in implementations of `hook_update_1000()`.

Along the way: code formatting (remove whitespace at ends of lines) and fixing an issue in grammar_parser that issued an error if `$data` was a plain string.