### PR TITLE
Store booleans properly in the config file

### DIFF
--- a/conversions/call.inc
+++ b/conversions/call.inc
@@ -69,6 +69,16 @@ function coder_upgrade_upgrade_call_variable_get_alter(&$node, &$reader) { // DO
         $value = 'dynamic value in file ' . $path . ' line ' . $node->line;
       }
     }
+
+    // Boolean initial values need to be stored as Booleans, not strings.
+    $value_uc = strtoupper($value);
+    if ($value_uc == 'TRUE') {
+      $value = TRUE;
+    }
+    elseif ($value_uc == 'FALSE') {
+      $value = FALSE;
+    }
+
     $config->set($variable, $value);
     $config->save();
 

--- a/conversions/end.inc
+++ b/conversions/end.inc
@@ -359,7 +359,13 @@ function coder_upgrade_create_update_1000($module_name, &$reader, &$nodes, $conf
   $body->insertLast($body_content);
 
   foreach ($config_data as $key => $line) {
-    $string = "  \$config->set('$key', update_variable_get('$key', '$line'));";
+    if (is_bool($line)) {
+      $line = $line ? 'TRUE' : 'FALSE';
+      $string = "  \$config->set('$key', update_variable_get('$key', $line));";
+    }
+    else {
+      $string = "  \$config->set('$key', update_variable_get('$key', '$line'));";
+    }
     $body_content = $editor->textToStatements($string)->getElement(0);
     $body->insertLast($body_content);
   }


### PR DESCRIPTION
Booleans were being stored as strings in the config file. This stores them as booleans.

This addresses "Forces TRUE/FALSE to be strings in config file" in https://github.com/backdrop-contrib/coder_upgrade/issues/26.