### PR TITLE
Issue 59: PHP Fatal error: Class 'SearchApiAbstractService' not found

### DIFF
--- a/includes/conversion.inc
+++ b/includes/conversion.inc
@@ -548,7 +548,7 @@ function coder_upgrade_directory_list() {
 /**
  * Returns list of contributed modules.
  *
- * @param null $core
+ * @param bool $core
  *   Indicates whether to return core modules regardless of settings variable.
  * @param integer $status
  *   Indicates status of modules to return.
@@ -566,7 +566,7 @@ function coder_upgrade_module_list($core = NULL, $status = -1) {
           REPLACE(filename, CONCAT('/', name, '.', type), '') AS directory
           FROM {system}
           WHERE type = 'module'
-          AND filename $like 'modules/%'
+          AND filename $like 'core/%'
           $where
           ORDER BY directory, name";
   $default_value = 0;


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/coder_upgrade/issues/59.