### PR TITLE
Issue #92: Change PGPParser:exceptionHandler to public.

### DIFF
--- a/grammar_parser/parser.inc
+++ b/grammar_parser/parser.inc
@@ -409,7 +409,7 @@ class PGPParser {
    *
    * @see set_exception_handler
    */
-  protected function exceptionHandler($exception) {
+  public function exceptionHandler($exception) {
     $backtrace = $exception->getTrace();
     // Push on top of the backtrace the call that generated the exception.
     array_unshift($backtrace, array(


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/coder_upgrade/issues/92.